### PR TITLE
chore: support cluster id

### DIFF
--- a/crates/cluster/src/member.rs
+++ b/crates/cluster/src/member.rs
@@ -64,7 +64,7 @@ impl Membership {
     }
 
     pub fn update_member(&mut self, member: MemberState) {
-        match self.members.entry(member.info.id) {
+        match self.members.entry(member.info.node_id) {
             Entry::Occupied(mut entry) => {
                 let current = entry.get_mut();
                 if current.info.incarnation < member.info.incarnation {

--- a/crates/cluster/src/node.rs
+++ b/crates/cluster/src/node.rs
@@ -25,20 +25,28 @@ use crate::ClusterError;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct NodeInfo {
-    pub id: Uuid,
-    pub name: String,
-    pub addr: String,
-    pub peer_addr: String,
+    pub node_id: Uuid,
+    pub node_name: String,
+    pub cluster_id: String,
+    pub advertise_addr: String,
+    pub advertise_peer_addr: String,
     pub incarnation: u64,
 }
 
 impl NodeInfo {
-    pub fn init(id: Option<Uuid>, name: String, addr: String, peer_addr: String) -> Self {
+    pub fn init(
+        node_id: Option<Uuid>,
+        node_name: String,
+        cluster_id: String,
+        addr: String,
+        peer_addr: String,
+    ) -> Self {
         Self {
-            id: id.unwrap_or_else(Uuid::new_v4),
-            name,
-            addr,
-            peer_addr,
+            node_id: node_id.unwrap_or_else(Uuid::new_v4),
+            node_name,
+            cluster_id,
+            advertise_addr: addr,
+            advertise_peer_addr: peer_addr,
             incarnation: 0,
         }
     }

--- a/crates/cluster/src/proxy.rs
+++ b/crates/cluster/src/proxy.rs
@@ -48,11 +48,11 @@ impl Proxy {
             false
         }) {
             if let Some(target) = members.get(&id) {
-                if target.info.id == self.gossip.current().id {
+                if target.info.node_id == self.gossip.current().node_id {
                     return RouteDest::Local;
                 }
 
-                RouteDest::RemoteAddr(target.info.addr.clone())
+                RouteDest::RemoteAddr(target.info.advertise_addr.clone())
             } else {
                 RouteDest::Local
             }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -53,6 +53,8 @@ pub enum ServerConfig {
         advertise_peer_addr: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         initial_advertise_peer_addrs: Option<Vec<String>>,
+        #[serde(default = "default_cluster_id")]
+        cluster_id: String,
     },
 }
 
@@ -79,6 +81,10 @@ fn default_dir() -> PathBuf {
 
 fn default_data_dir() -> PathBuf {
     PathBuf::from("/var/lib/percas/data")
+}
+
+fn default_cluster_id() -> String {
+    "percas-cluster".to_string()
 }
 
 pub fn node_file_path(base_dir: &Path) -> PathBuf {


### PR DESCRIPTION
Part of #35 

This PR introduced the concept of cluster id, which is used to identify a cluster.

Since we don't have a explicit join/leave mechanism now, the validation of cluster id is ignored for now.