### PR TITLE
chore: disable enforcement of http2

### DIFF
--- a/crates/cluster/src/gossip.rs
+++ b/crates/cluster/src/gossip.rs
@@ -362,10 +362,7 @@ struct Transport {
 
 impl Transport {
     pub fn new() -> Self {
-        let client = ClientBuilder::new()
-            .http2_prior_knowledge()
-            .build()
-            .unwrap();
+        let client = ClientBuilder::new().build().unwrap();
         Transport { client }
     }
 


### PR DESCRIPTION
Enforcing http2 without TLS may encouter `invalid frame size` error.