### PR TITLE
fix(foyer): bump foyer to v0.17.3 for bugfixs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,11 +898,10 @@ dependencies = [
 
 [[package]]
 name = "foyer"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae35d844b513ec9a2477ffc9c9b63cbe07665dcb6ab984d7b0177a705bcb81c3"
+checksum = "635c7077026867cb5e5ea576c461f29b1c4151fce7a9d7cc3a1b1a9902d95c65"
 dependencies = [
- "ahash",
  "anyhow",
  "equivalent",
  "foyer-common",
@@ -918,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "foyer-common"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05d527524ec9df060ab6fd4b188105b289343efc8b976e57a21487302753ac8"
+checksum = "7ed2316785e80137c7b91bb74dab1dc1967c3272df05825397b73ae8fc527041"
 dependencies = [
  "ahash",
  "bytes",
@@ -945,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "foyer-memory"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9acca85a3d93a5213a07c75c67c48ff0b85e150281a6cd729a2e746bedcad02d"
+checksum = "090cf5b89d49fd61e7da9bfae3a1aef605f03196d542b2f8171c74f3add013f4"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -970,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "foyer-storage"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d6320913ca299e5f3731e50dd9246f7e26278196097919b32aae116389761c"
+checksum = "095e857c97d6339d4a4a6424b88d08fe08ad0366bfbfaf65d6ddf55baf3d2a38"
 dependencies = [
  "ahash",
  "allocator-api2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ error-stack = { version = "0.5", default-features = false, features = [
 fastimer = { version = "0.9.0" }
 fastrace = { version = "0.7.9" }
 fastrace-opentelemetry = { version = "0.10.0" }
-foyer = { version = "0.17.1", features = ["nightly"] }
+foyer = { version = "0.17.3", features = ["nightly"] }
 futures-util = { version = "0.3.31" }
 gix-discover = { version = "0.40.1" }
 googletest = { version = "0.14.0" }


### PR DESCRIPTION
# Related changelog

## 2025-05-22

### Releases

| crate | version |
| - | - |
| foyer | 0.17.3 |
| foyer-common | 0.17.3 |
| foyer-memory | 0.17.3 |
| foyer-storage | 0.17.3 |
| foyer-bench | 0.17.3 |

### Changes

- Use `DefaultHasher` (alias for `std::hash::BuilderHasherDefault<ahash::AHaser>`) as the default hasher to guarantee hash algorithm stable across runs.

## 2025-05-14

### Releases

| crate | version |
| - | - |
| foyer | 0.17.2 |
| foyer-common | 0.17.2 |
| foyer-memory | 0.17.2 |
| foyer-storage | 0.17.2 |
| foyer-bench | 0.17.2 |

### Changes

- Fix disk cache return wrong entry on key hash collision.