### PR TITLE
chore: use murmur3 instead of sha256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,6 +2115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "murmur3"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
+
+[[package]]
 name = "naive-timer"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2426,13 +2432,13 @@ dependencies = [
  "jiff",
  "log",
  "mea",
+ "murmur3",
  "percas-core",
  "poem",
  "rand 0.9.2",
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
  "thiserror",
  "tokio",
  "uuid",
@@ -3219,17 +3225,6 @@ checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
 dependencies = [
  "digest",
  "sha1",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ logforth = { version = "0.27.0", features = [
 ] }
 mea = { version = "0.4.2" }
 mixtrics = { version = "0.2", features = ["opentelemetry_0_30"] }
+murmur3 = { version = "0.5.2" }
 opentelemetry = { version = "0.30.0", features = ["trace", "metrics"] }
 opentelemetry-otlp = { version = "0.30.0", features = [
   "trace",
@@ -102,7 +103,6 @@ scopeguard = { version = "1.2.0" }
 sealed_test = { version = "1.1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
-sha2 = { version = "0.10.8" }
 shadow-rs = { version = "1.0.0", default-features = false }
 sysinfo = { version = "0.37.0" }
 tempfile = { version = "3.19.1" }

--- a/crates/cluster/Cargo.toml
+++ b/crates/cluster/Cargo.toml
@@ -31,13 +31,13 @@ fastimer = { workspace = true }
 jiff = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
+murmur3 = { workspace = true }
 percas-core = { workspace = true }
 poem = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-sha2 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }


### PR DESCRIPTION
Murmur3 is more lightweight for hash ring calculation.